### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
           - 'head'
         gem: ['sunspot', 'sunspot_rails', 'sunspot_solr']
         update-format: ['xml', 'json']

--- a/sunspot/spec/integration/field_grouping_spec.rb
+++ b/sunspot/spec/integration/field_grouping_spec.rb
@@ -19,8 +19,7 @@ describe "field grouping" do
       group :title
     end
 
-    expect(search.group(:title).groups).to include { |g| g.value == "Title1" }
-    expect(search.group(:title).groups).to include { |g| g.value == "Title2" }
+    expect(search.group(:title).groups.map(&:value)).to include("Title1", "Title2")
   end
 
   it "returns the number of matches unique groups" do


### PR DESCRIPTION
対象：全てのRubyのバージョン
```
Failures:

  1) field grouping allows grouping by a field
     Failure/Error: expect(search.group(:title).groups).to include { |g| g.value == "Title1" }

     ArgumentError:
       include() is not supported, please supply an argument
     # ./spec/integration/field_grouping_spec.rb:22:in 'block (2 levels) in <top (required)>'

Finished in 7.29 seconds (files took 0.29196 seconds to load)
1426 examples, 1 failure, 1 pending

Failed examples:

rspec ./spec/integration/field_grouping_spec.rb:17 # field grouping allows grouping by a field
```
